### PR TITLE
Change input device without page reload

### DIFF
--- a/src/PeerMeeting.Host/ClientApp/src/CommonUtils.js
+++ b/src/PeerMeeting.Host/ClientApp/src/CommonUtils.js
@@ -36,12 +36,27 @@ var CommonUtils = {
       return null;
     },
     bytesToSize: function (bytes) {
-      var k = 1000;
-      var sizes = ["Bytes", "KB", "MB", "GB", "TB"];
-      if (bytes <= 0) return "0 Bytes";
-      var i = parseInt(Math.floor(Math.log(bytes) / Math.log(k)), 10);
-      if (!sizes[i]) return "0 Bytes";
-      return (bytes / Math.pow(k, i)).toPrecision(3) + " " + sizes[i];
+      var k = 1000
+      var sizes = ["Bytes", "KB", "MB", "GB", "TB"]
+      if (bytes <= 0) return "0 Bytes"
+      var i = parseInt(Math.floor(Math.log(bytes) / Math.log(k)), 10)
+      if (!sizes[i]) return "0 Bytes"
+      return (bytes / Math.pow(k, i)).toPrecision(3) + " " + sizes[i]
+    },
+    pushEventToCallbacks: function(callbacks, event){
+      callbacks.forEach(callback =>{
+        callback(event)
+      })
+    },
+    extractExtraData: function(connection, userid){
+      var extra = undefined
+      if(connection.userid == userid) extra = connection.extra
+      else extra = connection.getExtraData(userid)
+      if(!extra.audioMuted)
+        extra.audioMuted = false
+      if(!extra.videoMuted)
+        extra.videoMuted = false
+      return extra
     }
 }
 export default CommonUtils

--- a/src/PeerMeeting.Host/ClientApp/src/components/room/ControlBar.vue
+++ b/src/PeerMeeting.Host/ClientApp/src/components/room/ControlBar.vue
@@ -42,10 +42,12 @@ export default {
       this.state.videoEnabled = !this.state.videoEnabled;
       RTCUtils.SwitchVideoMute(this.connection, this.state.videoEnabled);
       RTCUtils.SwitchAudioMute(this.connection, this.state.audioEnabled); // Temporaty patch for enable (if enabled) mic after video disabled
+      if(this.state.videoEnabled) this.connection.renegotiate();
     },
     toggleAudio: function () {
       this.state.audioEnabled = !this.state.audioEnabled;
       RTCUtils.SwitchAudioMute(this.connection, this.state.audioEnabled);
+      if(this.state.audioEnabled) this.connection.renegotiate();
     },
     shareScreen: function () {
       this.connection.attachStreams.forEach((s) => s.stop());

--- a/src/PeerMeeting.Host/ClientApp/src/components/room/participant/ConnectionInfo.vue
+++ b/src/PeerMeeting.Host/ClientApp/src/components/room/participant/ConnectionInfo.vue
@@ -1,0 +1,43 @@
+<template>
+  <b-toast
+    :id="'toast-' + this.userId"
+    class="connection-toast"
+    title="Connection Info"
+    variant="secondary"
+    static
+    no-auto-hide
+  >
+    Bandwidth: {{ this.bytesToSize(this.stats.bandwidth) }}<br />
+    State: {{ this.stats.connectionState }}<br />
+    Local: {{ this.stats.ips.local }} {{ this.stats.transport.local }}<br />
+    Remote: {{ this.stats.ips.remote }} {{ this.stats.transport.remote }}<br />
+    Data transfered: {{ this.bytesToSize(this.stats.data.receive) }}
+    <b-icon icon="arrow-down-up" />
+    {{ this.bytesToSize(this.stats.data.send) }} <br />
+    RTT: {{ this.stats.rtt }} s.
+  </b-toast>
+</template>
+
+<script>
+import CommonUtils from "@/CommonUtils";
+export default {
+  name: "ConnectionInfo",
+  props: {
+    userId: String,
+    stats: Object,
+  },
+  methods:{
+    bytesToSize: CommonUtils.bytesToSize,
+  }
+};
+</script>
+
+<style>
+.connection-toast {
+  z-index: 41;
+  top: 3.4em;
+  left: 1em;
+  position: absolute;
+  text-align: left;
+}
+</style>

--- a/src/PeerMeeting.Host/ClientApp/src/components/room/participant/ParticipantBlock.vue
+++ b/src/PeerMeeting.Host/ClientApp/src/components/room/participant/ParticipantBlock.vue
@@ -42,26 +42,7 @@
     >
       <b-icon icon="bar-chart-fill" />
     </b-button>
-
-    <b-toast
-      :id="'toast-' + this.streamEvent.userid"
-      class="connection-toast"
-      title="Connection Info"
-      variant="secondary"
-      static
-      no-auto-hide
-    >
-      Bandwidth: {{ this.bytesToSize(this.stats.bandwidth) }}<br />
-      State: {{ this.stats.connectionState }}<br />
-      Local: {{ this.stats.ips.local }} {{ this.stats.transport.local }}<br />
-      Remote: {{ this.stats.ips.remote }} {{ this.stats.transport.remote
-      }}<br />
-      Data transfered: {{ this.bytesToSize(this.stats.data.receive) }}
-      <b-icon icon="arrow-down-up" />
-      {{ this.bytesToSize(this.stats.data.send) }} <br />
-      RTT: {{ this.stats.rtt }} s.
-    </b-toast>
-
+    <connection-info :userId="this.streamEvent.userid" :stats="this.stats"/>
     <b-icon
       class="audio-muted-icon"
       :icon="this.streamEvent.extra.audioMuted ? 'mic-mute' : 'mic'"
@@ -82,8 +63,12 @@
 <script>
 import CommonUtils from "@/CommonUtils";
 import PeerStats from "@/services/PeerStats";
+import ConnectionInfo from "@/components/room/participant/ConnectionInfo";
 export default {
   name: "ParticipantBlock",
+  components:{
+    ConnectionInfo
+  },
   data: () => {
     return {
       fullscreen: false,
@@ -164,7 +149,6 @@ export default {
         this.streamEvent
       );
     },
-    bytesToSize: CommonUtils.bytesToSize,
     streamValidate: function(){
       if (this.connection.userid === this.streamEvent.userid) return;
       if(!this.streamEvent.mediaElement) return;
@@ -189,7 +173,11 @@ export default {
         self.stats = stats;
       }, 3000);
     },
+    streamEventChangeCallback: function(){
+      this.$forceUpdate();
+    },
     prepare: function (event) {
+      event.changeCallback = this.streamEventChangeCallback;
       var card = document.getElementById("card-" + event.userid);
       if(card == null){
         var self = this;
@@ -218,7 +206,7 @@ export default {
         self.tryGetProfile();
         self.enablePeerStats(newVal);
       }, 400);
-    },
+    }
   },
   mounted: function () {
     var self = this;
@@ -318,13 +306,6 @@ export default {
   top: 1.8em;
   z-index: 40;
   border-style: hidden;
-}
-.connection-toast {
-  z-index: 41;
-  top: 3.4em;
-  left: 1em;
-  position: absolute;
-  text-align: left;
 }
 .audio-muted-icon {
   position: absolute;

--- a/src/PeerMeeting.Host/ClientApp/src/components/room/participant/ParticipantBlock.vue
+++ b/src/PeerMeeting.Host/ClientApp/src/components/room/participant/ParticipantBlock.vue
@@ -253,11 +253,6 @@ export default {
   height: 100%;
 }
 @-moz-document url-prefix() {
-  .user-block video {
-    background-color: transparent;
-    z-index: 1;
-    height: inherit;
-  }
   .half-screen video{
     height: unset;
   }

--- a/src/PeerMeeting.Host/ClientApp/src/components/settings/DevicesTab.vue
+++ b/src/PeerMeeting.Host/ClientApp/src/components/settings/DevicesTab.vue
@@ -1,0 +1,115 @@
+<template>
+  <b-tab title="Devices">
+    <b-alert show variant="warning"
+      >If changes not applyed, need reload page.</b-alert
+    >
+    <b-form-group description="Audio input device" label="Audio input">
+      <b-form-select
+        v-model="audioInput"
+        :options="audioDevices"
+      ></b-form-select>
+    </b-form-group>
+    <b-form-group description="Video input device" label="Video input">
+      <b-form-select
+        v-model="videoInput"
+        :options="videoDevices"
+      ></b-form-select>
+    </b-form-group>
+    <div class="save-button" style="width: 210px;">
+      <b-button
+        class="mr-1"
+        variant="outline-warning"
+        @click="reload"
+        >Reload devices</b-button>
+      <b-button
+        variant="outline-secondary"
+        @click="saveDevices"
+        >Save</b-button
+      >
+    </div>
+  </b-tab>
+</template>
+
+<script>
+import CommonUtils from "@/CommonUtils";
+export default {
+  name: "DevicesTab",
+  data: () => {
+    return {
+      audioInput: null,
+      videoInput: null,
+      audioDevices: [],
+      videoDevices: [],
+    };
+  },
+  methods: {
+    reload: function(){
+      CommonUtils.pushEventToCallbacks(
+        this.$store.state.application.inputDeviceChangedCallbacks,
+        {}
+      );
+      this.$bvToast.toast("Reinitialization input devices.", {
+        title: `Settings notification`,
+        variant: "warning",
+        solid: true,
+      });
+    },
+    saveDevices: function () {
+      var deviceSettings = this.$store.state.application.deviceSettings;
+      if (this.audioInput) deviceSettings.audioInput = this.audioInput;
+      if (this.videoInput) deviceSettings.videoInput = this.videoInput;
+      CommonUtils.pushEventToCallbacks(
+        this.$store.state.application.inputDeviceChangedCallbacks,
+        {}
+      );
+      this.$store.commit("changeDeviceSettings", deviceSettings);
+      this.$bvToast.toast("Devices saved.", {
+        title: `Settings notification`,
+        variant: "success",
+        solid: true,
+      });
+    },
+    fetchDevices: function () {
+      this.audioDevices = Array.from(
+        this.$store.state.application.mediaDevices.filter(
+          (x) => x.kind === "audioinput"
+        ),
+        (x) => {
+          return { value: x.deviceId, text: x.label ? x.label : x.deviceId };
+        }
+      );
+      this.videoDevices = Array.from(
+        this.$store.state.application.mediaDevices.filter(
+          (x) => x.kind === "videoinput"
+        ),
+        (x) => {
+          return { value: x.deviceId, text: x.label ? x.label : x.deviceId };
+        }
+      );
+      this.$forceUpdate();
+    },
+  },
+  watch: {
+    // eslint-disable-next-line
+    "$store.state.application.deviceSettings": function (to, from) {
+      this.audioInput = this.$store.state.application.deviceSettings.audioInput;
+      this.videoInput = this.$store.state.application.deviceSettings.videoInput;
+    },
+    // eslint-disable-next-line
+    "$store.state.application.mediaDevices": function (to, from) {
+      this.fetchDevices();
+    },
+  },
+  mounted: function () {
+    this.fetchDevices();
+  },
+  created: function () {
+    this.audioInput = this.$store.state.application.deviceSettings.audioInput;
+    this.videoInput = this.$store.state.application.deviceSettings.videoInput;
+    this.fetchDevices();
+  },
+};
+</script>
+
+<style>
+</style>

--- a/src/PeerMeeting.Host/ClientApp/src/components/settings/ProfileTab.vue
+++ b/src/PeerMeeting.Host/ClientApp/src/components/settings/ProfileTab.vue
@@ -1,0 +1,91 @@
+<template>
+  <b-tab title="Profile" active>
+    <b-form-group
+      description="User name displayed to all participants in room"
+      label="Enter username:"
+      label-for="input-1"
+    >
+      <b-form-input
+        v-model="username"
+        trim
+        @keyup.enter="SaveProfile"
+      ></b-form-input>
+    </b-form-group>
+    <b-form-group
+      description="Gravatar email identificator, for display you avatar to participants"
+      label="Enter gravatar email:"
+      label-for="input-1"
+    >
+      <b-form-input
+        v-model="email"
+        trim
+        @keyup.enter="SaveProfile"
+      ></b-form-input>
+    </b-form-group>
+    <b-button
+      variant="outline-secondary"
+      class="save-button"
+      @click="SaveProfile"
+      >Save</b-button
+    >
+  </b-tab>
+</template>
+
+<script>
+export default {
+    name: "ProfileTab",
+  data: () => {
+    return {
+      username: "",
+      email: "",
+      md5: require("md5"),
+    };
+  },
+  methods: {
+    SaveProfile: function () {
+      if (!this.username || this.username.length < 2) return;
+      var profile = {
+        avatar: null,
+        name: this.username,
+        email: this.email,
+      };
+
+      if (this.email && this.email.length > 0) {
+        var emailHash = this.md5(this.email);
+        profile.avatar =
+          "https://www.gravatar.com/avatar/" + emailHash + "?s=256&d=identicon";
+      } else {
+        profile.avatar = null;
+      }
+      this.$store.commit("changeProfile", profile);
+      this.$bvToast.toast("Profile saved", {
+        title: `Settings notification`,
+        variant: "success",
+        solid: true,
+      });
+    },
+  },
+  watch: {
+    // eslint-disable-next-line
+    "$store.state.application.profile": function (to, from) {
+      this.username = this.$store.state.application.profile
+        ? this.$store.state.application.profile.name
+        : "";
+      this.email = this.$store.state.application.profile
+        ? this.$store.state.application.profile.email
+        : "";
+    }
+  },
+  mounted: function () {
+    this.username = this.$store.state.application.profile
+      ? this.$store.state.application.profile.name
+      : "";
+    this.email = this.$store.state.application.profile
+      ? this.$store.state.application.profile.email
+      : "";
+  }
+};
+</script>
+
+<style>
+</style>

--- a/src/PeerMeeting.Host/ClientApp/src/components/settings/SettingsDialog.vue
+++ b/src/PeerMeeting.Host/ClientApp/src/components/settings/SettingsDialog.vue
@@ -1,68 +1,15 @@
 <template>
   <b-modal id="settings-modal" size="lg" centered title="Settings">
     <b-tabs content-class="mt-3">
-      <b-tab title="Profile" active>
-        <b-form-group
-          description="User name displayed to all participants in room"
-          label="Enter username:"
-          label-for="input-1"
-        >
-          <b-form-input
-            v-model="username"
-            trim
-            @keyup.enter="SaveProfile"
-          ></b-form-input>
-        </b-form-group>
-        <b-form-group
-          description="Gravatar email identificator, for display you avatar to participants"
-          label="Enter gravatar email:"
-          label-for="input-1"
-        >
-          <b-form-input
-            v-model="email"
-            trim
-            @keyup.enter="SaveProfile"
-          ></b-form-input>
-        </b-form-group>
-        <b-button
-          variant="outline-secondary"
-          class="save-button"
-          @click="SaveProfile"
-          >Save</b-button
-        >
-      </b-tab>
-      <b-tab title="Devices">
-        <b-alert show variant="warning">Any changes to this section require a page reload.</b-alert>
-        <b-form-group
-          description="Audio input device"
-          label="Audio input"
-        >
-          <b-form-select
-            v-model="audioInput"
-            :options="audioDevices"
-          ></b-form-select>
-        </b-form-group>
-        <b-form-group
-          description="Video input device"
-          label="Video input"
-        >
-          <b-form-select
-            v-model="videoInput"
-            :options="videoDevices"
-          ></b-form-select>
-        </b-form-group>
-        <b-button
-          variant="outline-secondary"
-          class="save-button"
-          @click="SaveDevices"
-          >Save</b-button
-        >
-      </b-tab>
+      <profile-tab/>
+      <devices-tab/>
     </b-tabs>
   </b-modal>
 </template>
 
 <script>
+import ProfileTab from '@/components/settings/ProfileTab.vue';
+import DevicesTab from '@/components/settings/DevicesTab.vue';
 export default {
   name: "SettingsDialog",
   data: () => {
@@ -76,97 +23,10 @@ export default {
       md5: require("md5"),
     };
   },
-  methods: {
-    SaveProfile: function () {
-      if (!this.username || this.username.length < 2) return;
-      var profile = {
-        avatar: null,
-        name: this.username,
-        email: this.email,
-      };
-
-      if (this.email && this.email.length > 0) {
-        var emailHash = this.md5(this.email);
-        profile.avatar =
-          "https://www.gravatar.com/avatar/" + emailHash + "?s=256&d=identicon";
-      } else {
-        profile.avatar = null;
-      }
-      this.$store.commit("changeProfile", profile);
-      this.$bvToast.toast("Profile saved", {
-        title: `Settings notification`,
-        variant: "success",
-        solid: true,
-      });
-    },
-    SaveDevices: function () {
-      var deviceSettings = this.$store.state.application.deviceSettings;
-      if (this.audioInput) deviceSettings.audioInput = this.audioInput;
-      if (this.videoInput) deviceSettings.videoInput = this.videoInput;
-
-      this.$store.commit("changeDeviceSettings", deviceSettings);
-      this.$bvToast.toast("Devices saved. Need page reload", {
-        title: `Settings notification`,
-        variant: "warning",
-        solid: true,
-        autoHideDelay: 90000,
-        href: window.location.href
-      });
-    },
-    FetchDevices: function () {
-      this.audioDevices = Array.from(
-        this.$store.state.application.mediaDevices.filter(
-          (x) => x.kind === "audioinput"
-        ),
-        (x) => {
-          return { value: x.deviceId, text: x.label ? x.label : x.deviceId };
-        }
-      );
-      this.videoDevices = Array.from(
-        this.$store.state.application.mediaDevices.filter(
-          (x) => x.kind === "videoinput"
-        ),
-        (x) => {
-          return { value: x.deviceId, text: x.label ? x.label : x.deviceId };
-        }
-      );
-      this.$forceUpdate();
-    },
-  },
-  watch: {
-    // eslint-disable-next-line
-    "$store.state.application.profile": function (to, from) {
-      this.username = this.$store.state.application.profile
-        ? this.$store.state.application.profile.name
-        : "";
-      this.email = this.$store.state.application.profile
-        ? this.$store.state.application.profile.email
-        : "";
-    },
-    // eslint-disable-next-line
-    "$store.state.application.deviceSettings": function (to, from) {
-      this.audioInput = this.$store.state.application.deviceSettings.audioInput;
-      this.videoInput = this.$store.state.application.deviceSettings.videoInput;
-    },
-    // eslint-disable-next-line
-    "$store.state.application.mediaDevices": function (to, from) {
-      this.FetchDevices();
-    },
-  },
-  mounted: function () {
-    this.username = this.$store.state.application.profile
-      ? this.$store.state.application.profile.name
-      : "";
-    this.email = this.$store.state.application.profile
-      ? this.$store.state.application.profile.email
-      : "";
-    this.FetchDevices();
-  },
-  created: function () {
-    this.audioInput = this.$store.state.application.deviceSettings.audioInput;
-    this.videoInput = this.$store.state.application.deviceSettings.videoInput;
-    this.FetchDevices();
-  },
+  components:{
+    ProfileTab,
+    DevicesTab
+  }
 };
 </script>
 

--- a/src/PeerMeeting.Host/ClientApp/src/services/PeerStats.js
+++ b/src/PeerMeeting.Host/ClientApp/src/services/PeerStats.js
@@ -1,7 +1,7 @@
 // Copyright 2021 Klabukov Erik.
 // SPDX-License-Identifier: GPL-3.0-only
 /*eslint-disable*/
-export default class PeerStats{
+export default class PeerStats {
     timer = null;
     stats = {
         bandwidth: 0,
@@ -10,7 +10,7 @@ export default class PeerStats{
         transport: { local: "", remote: "" },
         data: { send: 0, receive: 0 },
         packets: { send: 0, receive: 0 },
-        codecs: {local: "", remote: ""},
+        codecs: { local: "", remote: "" },
         connectionState: "",
         rtt: 0.0,
     };
@@ -23,37 +23,38 @@ export default class PeerStats{
     constructor(PeerConnection) {
         this.PeerConnection = PeerConnection
         this.old.timestamp = new Date().getTime();
-        this.isFirefox = navigator.userAgent.indexOf("Firefox") != -1 
+        this.isFirefox = navigator.userAgent.indexOf("Firefox") != -1
     }
 
-    start(callback, interval){
-        if(!callback)
+    start(callback, interval) {
+        if (!callback)
             throw "Callback cannot be null";
         interval = interval || 3000;
         var self = this;
-        this.timer = setInterval(() =>{
-            self.PeerConnection.getStats().then( r => {
+        this.timer = setInterval(() => {
+            self.PeerConnection.getStats().then(r => {
                 self.parseReport(r);
                 callback(self.stats);
             });
         }, interval)
     }
 
-    stop(){
-        if(!this.timer) return;
+    stop() {
+        if (!this.timer) return;
         clearInterval(this.timer);
     }
 
-    parseReport(report){
+    parseReport(report) {
         var self = this;
-        this.stats.connectionState = this.isFirefox 
-        ? this.PeerConnection.iceConnectionState
-        : this.PeerConnection.connectionState;
-        report.forEach( r => {
-                if(r.type == 'transport' || (self.isFirefox && r.type == 'candidate-pair' && r.nominated)){
+        this.stats.connectionState = this.isFirefox
+            ? this.PeerConnection.iceConnectionState
+            : this.PeerConnection.connectionState;
+        report.forEach(r => {
+            if (r.type == 'transport' || (self.isFirefox && r.type == 'candidate-pair' && r.nominated)) {
                 var perSecond = (r.timestamp - self.old.timestamp) / 1000;
                 perSecond = perSecond < 1 ? 1 : perSecond;
                 self.old.timestamp = r.timestamp;
+
                 //Bandwidth and bytes send / received
                 self.stats.data.send = r.bytesSent;
                 self.stats.data.receive = r.bytesReceived;
@@ -62,24 +63,27 @@ export default class PeerStats{
                 self.old.data.receive = r.bytesReceived;
                 self.stats.packets.send = r.packetsSent;
                 self.stats.packets.receive = r.packetsReceived;
+
                 //candidate pair
                 var candidatePair = self.isFirefox ? r : report.get(r.selectedCandidatePairId);
-                self.stats.rtt = self.isFirefox ? 0 : candidatePair.totalRoundTripTime;
+                self.stats.rtt = self.isFirefox ? 0 : candidatePair.totalRoundTripTime
+
                 var localCandidate = report.get(candidatePair.localCandidateId);
                 self.stats.ips.local = (self.isFirefox ? localCandidate.address : localCandidate.ip) + ":" + localCandidate.port;
                 self.stats.transport.local = localCandidate.protocol;
                 self.stats.stunOrTurn.local =
-                localCandidate.candidateType.indexOf("relayed") !== -1
-                ? "TURN"
-                : "STUN";
+                    localCandidate.candidateType.indexOf("relayed") !== -1
+                        ? "TURN"
+                        : "STUN";
+
                 var remoteCandidate = report.get(candidatePair.remoteCandidateId);
                 self.stats.ips.remote = (self.isFirefox ? remoteCandidate.address : remoteCandidate.ip) + ":" + remoteCandidate.port;
                 self.stats.transport.remote = remoteCandidate.protocol;
                 self.stats.stunOrTurn.remote =
-                remoteCandidate.candidateType.indexOf("relayed") !== -1
-                ? "TURN"
-                : "STUN";
-              return
+                    remoteCandidate.candidateType.indexOf("relayed") !== -1
+                        ? "TURN"
+                        : "STUN";
+                return
             }
         });
     }

--- a/src/PeerMeeting.Host/ClientApp/src/services/store.js
+++ b/src/PeerMeeting.Host/ClientApp/src/services/store.js
@@ -16,6 +16,7 @@ export default new Vuex.Store({
       },
       roomHistory: [],
       mediaDevices: [],
+      inputDeviceChangedCallbacks: [],
       version: ''
     }
   },
@@ -58,6 +59,9 @@ export default new Vuex.Store({
     },
     updateMediaDevices (state, payload) {
       state.application.mediaDevices = payload
+    },
+    addDeviceChangedCallback (state, payload) {
+      state.application.inputDeviceChangedCallbacks.push(payload)
     },
     changeVersion (state, value) {
       state.application.version = value

--- a/src/PeerMeeting.Host/ClientApp/src/views/Room.vue
+++ b/src/PeerMeeting.Host/ClientApp/src/views/Room.vue
@@ -99,12 +99,12 @@ export default {
       });
     },
     userStatusChanged: function (event) {
-      if (
-        this.participants.has(event.userid) &&
+      if (this.participants.has(event.userid) &&
         event.status === "online" &&
-        event.extra
-      ) {
-        this.participants.get(event.userid).extra = event.extra;
+        event.extra) {
+        var participant = this.participants.get(event.userid);
+        participant.extra = event.extra;
+        if(participant.changeCallback) participant.changeCallback();
         return;
       }
       if (this.participants.has(event.userid) || event.status === "offline")

--- a/src/PeerMeeting.Host/Hubs/WebRtcHub.cs
+++ b/src/PeerMeeting.Host/Hubs/WebRtcHub.cs
@@ -18,7 +18,7 @@ namespace PeerMeeting.Host.Hubs
 
         public Task Send(string name, string message)
         {
-            _logger.LogInformation("Command: {CommandName} \t\t Message: {Message}", name, message);
+            _logger.LogDebug("Command: {CommandName} \t\t Message: {Message}", name, message);
             return Clients.Group(name).SendAsync(name, message);
         }
 

--- a/src/PeerMeeting.Host/PeerMeeting.Host.csproj
+++ b/src/PeerMeeting.Host/PeerMeeting.Host.csproj
@@ -12,6 +12,9 @@
 
   <!--Dev only-->
   <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
     <PackageReference Include="VueCliMiddleware" Version="3.1.1" />
   </ItemGroup>
 

--- a/src/PeerMeeting.Host/Program.cs
+++ b/src/PeerMeeting.Host/Program.cs
@@ -1,8 +1,11 @@
 // Copyright 2021 Klabukov Erik.
 // SPDX-License-Identifier: GPL-3.0-only
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Serilog;
 
 namespace PeerMeeting.Host
 {
@@ -17,7 +20,23 @@ namespace PeerMeeting.Host
             Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseStartup<Startup>();
+                    webBuilder.UseStartup<Startup>()
+                        .UseSerilog(ConfigureSerilog);
                 });
+
+        public static void ConfigureSerilog(WebHostBuilderContext ctx, LoggerConfiguration config)
+        {
+            config.ReadFrom.Configuration(ctx.Configuration);
+            AppDomain.CurrentDomain.UnhandledException += (sender, eventArgs) =>
+            {
+                var exception = eventArgs.ExceptionObject as Exception;
+                Log.Logger.ForContext<Program>().Error(exception, "Unhandled Exception");
+            };
+            TaskScheduler.UnobservedTaskException += (sender, eventArgs) =>
+            {
+                Log.Logger.ForContext<Program>().Error(eventArgs.Exception, "Unobserved Task Exception");
+            };
+        }
+
     }
 }

--- a/src/PeerMeeting.Host/Startup.cs
+++ b/src/PeerMeeting.Host/Startup.cs
@@ -6,10 +6,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.SpaServices;
 using PeerMeeting.Host.Hubs;
@@ -31,7 +27,11 @@ namespace PeerMeeting.Host
         {
             services.AddControllers();
             services.AddMvc();
-            services.AddSignalR();
+            services.AddSignalR(o =>
+            {
+                o.EnableDetailedErrors = true;
+                o.MaximumReceiveMessageSize = 256 * 1024; //256 KB
+            });
             services.AddSpaStaticFiles(c => c.RootPath = "ClientApp/dist");
             services.AddSingleton<WebRtcHub>();
             services.AddResponseCompression(options =>
@@ -65,7 +65,11 @@ namespace PeerMeeting.Host
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapHub<WebRtcHub>("/ws/webrtc");
+                endpoints.MapHub<WebRtcHub>("/ws/webrtc", o =>
+                {
+                    // zero for unlimited
+                    o.TransportMaxBufferSize = 0;
+                });
                 endpoints.MapControllers();
                 if (env.IsDevelopment())
                 {

--- a/src/PeerMeeting.Host/appsettings.Development.json
+++ b/src/PeerMeeting.Host/appsettings.Development.json
@@ -1,9 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  }
-}

--- a/src/PeerMeeting.Host/appsettings.Production.json
+++ b/src/PeerMeeting.Host/appsettings.Production.json
@@ -1,0 +1,11 @@
+{
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Error"
+      }
+    }
+  }
+}

--- a/src/PeerMeeting.Host/appsettings.json
+++ b/src/PeerMeeting.Host/appsettings.json
@@ -1,10 +1,20 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Error"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Async",
+        "Args": {
+          "configure": [ { "Name": "Console" } ]
+        }
+      }
+    ]
   },
   "AllowedHosts": "*"
 }

--- a/src/PeerMeeting.Host/runtimeconfig.template.json
+++ b/src/PeerMeeting.Host/runtimeconfig.template.json
@@ -1,0 +1,5 @@
+{
+  "configProperties": {
+    "System.Threading.ThreadPool.MinThreads": 7
+  }
+}


### PR DESCRIPTION
Client:
* Add reinitialize stream with new devices when is changed without page reload
* Fix workaround timer who generate empty cards when peer connected but all stream deleted
* Fix showing video or audio stream from user ( sometimes media track don't getting). New event 'renegotiate-needed' fix this
* Settings tabs moved to separate files

Server:
* Fix signalR limit on messsage (default 32kb but sometimes webrtc messages so fat (38kb)). Now limit 256kb and client reconnect successfully
* Change logger from microsoft to Serilog. Because only Serilog has async logger (webrtc hub generate more debug messages)